### PR TITLE
feat: add GitHub Actions workflow for building Go project

### DIFF
--- a/.github/go.yml
+++ b/.github/go.yml
@@ -1,0 +1,25 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24.3'
+
+    - name: Build
+      run: go build -o ./bin -v ./cmd/server/

--- a/.github/go.yml
+++ b/.github/go.yml
@@ -21,5 +21,8 @@ jobs:
       with:
         go-version: '1.24.3'
 
+    - name: Create bin directory
+      run: mkdir -p ./bin
+
     - name: Build
       run: go build -o ./bin -v ./cmd/server/


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for building a Go project. The workflow is configured to run on pushes and pull requests to the `master` branch.

Key changes:

### CI/CD Workflow Addition:
* [`.github/go.yml`](diffhunk://#diff-1db0c8b48c5b1f2e13afbe67a4fac3e24ee4285bb6da7ff59e86ccea6af1f206R1-R25): Introduced a new GitHub Actions workflow named "Go" to automate the build process for a Go project. It sets up Go version `1.24.3`, checks out the repository, and builds the project using `go build`.